### PR TITLE
1.17.x: Change JDK target to Java 16 to allow the vast majority of users to actually be able to load TelePistons using the default JDK 16 used for Minecraft 1.17.x.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version


### PR DESCRIPTION
1.17.x: Change JDK target to Java 16 to allow the vast majority of users to actually be able to load TelePistons using the default JDK 16 used for Minecraft 1.17.x.

No code changes were required as a result of this change.